### PR TITLE
Fix issue with C++ endf float converter

### DIFF
--- a/src/endf/_records.cpp
+++ b/src/endf/_records.cpp
@@ -25,11 +25,23 @@ double cfloat_endf(const char* buffer)
   int n = std::strlen(buffer);
 
   int i;
+
+  // Ensure that the length of the buffer doesn't exceed the size of arr
+  if (n > 11) {
+    throw std::runtime_error("Input buffer exceeds maximum length");
+  }
+
   for (i = 0; i < n; ++i) {
     char c = buffer[i];
 
     // Skip whitespace characters
-    if (c == ' ') continue;
+    if (std::isspace(c)) continue;
+
+    // Catch leading minus sign
+    if (j == 0 && c == '-') {
+      arr[0] = c;
+      continue;
+    }
 
     if (found_significand) {
       if (!found_exponent) {
@@ -51,6 +63,7 @@ double cfloat_endf(const char* buffer)
 
     // Copy character
     arr[j++] = c;
+    
   }
 
   // Done copying. Add null terminator and convert to double

--- a/src/endf/_records.cpp
+++ b/src/endf/_records.cpp
@@ -30,7 +30,7 @@ double cfloat_endf(const char* buffer)
     char c = buffer[i];
 
     // Skip whitespace characters
-    if (std::isspace(c)) continue;
+    if (c == ' ') continue;
 
     if (found_significand) {
       if (!found_exponent) {

--- a/src/endf/_records.cpp
+++ b/src/endf/_records.cpp
@@ -16,7 +16,7 @@
 
 double cfloat_endf(const char* buffer)
 {
-  char arr[12]; // 11 characters plus a null terminator
+  char arr[13]; // 11 characters plus e and a null terminator
   int j = 0; // current position in arr
   int found_significand = 0;
   int found_exponent = 0;
@@ -26,22 +26,11 @@ double cfloat_endf(const char* buffer)
 
   int i;
 
-  // Ensure that the length of the buffer doesn't exceed the size of arr
-  if (n > 11) {
-    throw std::runtime_error("Input buffer exceeds maximum length");
-  }
-
   for (i = 0; i < n; ++i) {
     char c = buffer[i];
 
     // Skip whitespace characters
     if (std::isspace(c)) continue;
-
-    // Catch leading minus sign
-    if (j == 0 && c == '-') {
-      arr[0] = c;
-      continue;
-    }
 
     if (found_significand) {
       if (!found_exponent) {


### PR DESCRIPTION
This closes #6 - at least for me, I noticed someone having similar issues in #4.

The crash seems to be a seg fault that occurs when the endf float being converted is negative, i.e. has a leading minus sign.

Positive numbers have leading whitespace so hit the continue statement and j is not incremented. Therefore, the first digit is placed at arr[0]. However, negative numbers had the leading minus sign placed at arr[0] and first digit at arr[1]. This means when the null terminator is placed at the end, for negative numbers this is at arr[12] so the crash occurs.

EDIT: my initial commit was not the correct solution, I think it is simply a case of increasing arr to be length 13 so it has space for both the e and null terminator if the input buffer is length 11. Apologies, some how my initial incorrect fix ran (I have no idea how!) but on restarting it failed. 

This would seem to me to be an issue across systems. 