### PR TITLE
Add tests for cfloat_endf

### DIFF
--- a/src/endf/_records.cpp
+++ b/src/endf/_records.cpp
@@ -1,4 +1,5 @@
 #include <cstdlib>
+#include <cstring> // for strlen
 
 #include <pybind11/pybind11.h>
 
@@ -11,7 +12,6 @@
 //! only whitespace is to be interpreted as a zero.
 //
 //! \param buffer character input from an ENDF file
-//! \param n Length of character input
 //! \return Floating point number
 
 double cfloat_endf(const char* buffer)
@@ -23,15 +23,13 @@ double cfloat_endf(const char* buffer)
 
   // limit n to 11 characters
   int n = std::strlen(buffer);
+  if (n > 11) n = 11;
 
-  int i;
-
-  for (i = 0; i < n; ++i) {
+  for (int i = 0; i < n; ++i) {
     char c = buffer[i];
 
     // Skip whitespace characters
     if (c == ' ') continue;
-
     if (found_significand) {
       if (!found_exponent) {
         if (c == '+' || c == '-') {
@@ -52,7 +50,6 @@ double cfloat_endf(const char* buffer)
 
     // Copy character
     arr[j++] = c;
-    
   }
 
   // Done copying. Add null terminator and convert to double

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Paul Romano
+# SPDX-License-Identifier: MIT
+
+from pytest import approx
+from endf._records import float_endf
+
+
+def test_float_sign():
+    assert float_endf('+3.2146') == approx(3.2146)
+    assert float_endf('-2.225002+6') == approx(-2.225002e6)
+
+
+def test_float_no_leading_digit():
+    assert float_endf('.12345') == approx(0.12345)
+
+
+def test_float_double_digit_exponent():
+    assert float_endf('6.022+23') == approx(6.022e23)
+    assert float_endf('6.022-23') == approx(6.022e-23)
+
+
+def test_float_whitespace():
+    assert float_endf(' +1.01+ 2') == approx(101.0)
+    assert float_endf(' -1.01- 2') == approx(-0.0101)
+    assert float_endf('+ 2 . 3+ 1') == approx(23.0)
+    assert float_endf('-7 .8 -1') == approx(-0.78)
+
+
+def test_float_e_exponent():
+    assert float_endf('3.14e0') == approx(3.14)
+    assert float_endf('3.14E0') == approx(3.14)
+    assert float_endf('3.14e-1') == approx(0.314)
+
+
+def test_float_d_exponent():
+    assert float_endf('3.14d0') == approx(3.14)
+    assert float_endf('3.14D0') == approx(3.14)
+    assert float_endf('3.14d-1') == approx(0.314)
+
+
+def test_float_only_leading_digit():
+    assert float_endf('1+2') == approx(100.0)
+    assert float_endf('-1+2') == approx(-100.0)
+    assert float_endf('1.+2') == approx(100.0)
+    assert float_endf('-1.+2') == approx(-100.0)
+
+
+def test_float_empty():
+    assert float_endf('        ') == 0.0
+
+
+def test_float_buffer_size():
+    assert float_endf('9.876540000000000') == approx(9.87654)


### PR DESCRIPTION
Adds tests for the `cfloat_endf` function and fixes one case where a buffer that is more than 11 characters results in stack smashing.