### PR TITLE
Fix parsing of MF=6, LAW=2 (discrete two-body scattering)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023 Paul Romano
+Copyright (c) 2023-2025 Paul Romano
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -9,7 +9,7 @@
 from importlib.metadata import version as metadata_version
 
 project = 'ENDF Python Interface'
-copyright = '2023, Paul Romano'
+copyright = '2023-2025, Paul Romano'
 author = 'Paul Romano'
 
 release = metadata_version('endf')

--- a/src/endf/__init__.py
+++ b/src/endf/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from importlib.metadata import version, PackageNotFoundError

--- a/src/endf/ace.py
+++ b/src/endf/ace.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 OpenMC contributors and Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 OpenMC contributors and Paul Romano
 # SPDX-License-Identifier: MIT
 
 """This module is for reading ACE-format cross sections. ACE stands for "A

--- a/src/endf/data.py
+++ b/src/endf/data.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 import re

--- a/src/endf/fileutils.py
+++ b/src/endf/fileutils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 import os

--- a/src/endf/function.py
+++ b/src/endf/function.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 OpenMC contributors and Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 OpenMC contributors and Paul Romano
 # SPDX-License-Identifier: MIT
 
 from collections.abc import Iterable

--- a/src/endf/incident_neutron.py
+++ b/src/endf/incident_neutron.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/endf/material.py
+++ b/src/endf/material.py
@@ -1,12 +1,12 @@
-# SPDX-FileCopyrightText: 2023 OpenMC contributors and Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 OpenMC contributors and Paul Romano
 # SPDX-License-Identifier: MIT
 
 """Module for parsing and manipulating data from ENDF files.
 
 All the classes and functions in this module are based on the ENDF-102 report
 titled "ENDF-6 Formats Manual: Data Formats and Procedures for the Evaluated
-Nuclear Data Files". The version from January 2018 can be found at
-https://doi.org/10.2172/1425114.
+Nuclear Data Files". The version from September 2023 can be found at
+https://doi.org/10.2172/2007538.
 
 """
 import io

--- a/src/endf/mf1.py
+++ b/src/endf/mf1.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf12.py
+++ b/src/endf/mf12.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf13.py
+++ b/src/endf/mf13.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf14.py
+++ b/src/endf/mf14.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf15.py
+++ b/src/endf/mf15.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf2.py
+++ b/src/endf/mf2.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf23.py
+++ b/src/endf/mf23.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf26.py
+++ b/src/endf/mf26.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf27.py
+++ b/src/endf/mf27.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf28.py
+++ b/src/endf/mf28.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf3.py
+++ b/src/endf/mf3.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf33.py
+++ b/src/endf/mf33.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf34.py
+++ b/src/endf/mf34.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf4.py
+++ b/src/endf/mf4.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/src/endf/mf40.py
+++ b/src/endf/mf40.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf5.py
+++ b/src/endf/mf5.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from abc import ABC

--- a/src/endf/mf6.py
+++ b/src/endf/mf6.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf6.py
+++ b/src/endf/mf6.py
@@ -120,10 +120,11 @@ class DiscreteTwoBodyScattering:
         for i in range(NE):
             items, values = get_list_record(file_obj)
             _, E_i, LANG, _, NW, NL = items
-            dist = {'LANG': LANG, 'NW': NW, 'NL': NL}
+            dist = {'LANG': LANG, 'NW': NW, 'NL': NL, 'A_l': np.asarray(values)}
             data['E'][i] = E_i
-            data['A_l'] = np.asarray(values)
             data['distribution'].append(dist)
+
+        return data
 
 
 class ChargedParticleElasticScattering:

--- a/src/endf/mf7.py
+++ b/src/endf/mf7.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf8.py
+++ b/src/endf/mf8.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/mf9.py
+++ b/src/endf/mf9.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 Paul Romano
 # SPDX-License-Identifier: MIT
 
 from typing import TextIO

--- a/src/endf/reaction.py
+++ b/src/endf/reaction.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 OpenMC contributors and Paul Romano
+# SPDX-FileCopyrightText: 2023-2025 OpenMC contributors and Paul Romano
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations


### PR DESCRIPTION
I noticed that the `DiscreteTwoBodyScattering.dict_from_endf` method didn't return the dictionary it produced, and additionally the list of A_l values was not stored properly.