### PR TITLE
Require Python version 3.9 or higher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "numpy",
     "uncertainties",


### PR DESCRIPTION
I just found out that building wheels fails for PyPy 3.8:
https://github.com/paulromano/endf-python/actions/runs/16935216394/job/47990033426

In principle, we could just not build wheels for PyPy but given that Python 3.8 isn't supported anymore, an easier path is to just update our required Python version to 3.9.