### PR TITLE
Require Python version 3.10 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.7]
+
+### Fixed
+
+* Require Python version 3.10 or higher ([#25](https://github.com/paulromano/endf-python/pull/25))
+
 ## [0.1.6]
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [
     { name = "Paul Romano", email = "paul.k.romano@gmail.com" },
 ]
-license = { file = "LICENSE" }
+license = "MIT"
 description = "Python interface to ENDF-6 files"
 readme = "README.md"
 classifiers = [
@@ -16,19 +16,16 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: End Users/Desktop",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "uncertainties",


### PR DESCRIPTION
It looks like the latest version of pybind11 has dropped support for Python 3.9 so this PR updates our requirement to 3.10+