### PR TITLE
Update cibuildwheel to v3

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0  # needed for setuptools_scm
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17
+        uses: pypa/cibuildwheel@v3
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.8]
+
+### Fixed
+
+* Update cibuildwheel to v3 ([#26](https://github.com/paulromano/endf-python/pull/26))
+
 ## [0.1.7]
 
 ### Fixed


### PR DESCRIPTION
Evidently PyPy versions are pinned for a given version of cibuildwheel and the version we're using includes an outdated version of PyPy that has problems building wheels. This PR updates the cibuildwheel version so that wheel building should work.