### PR TITLE
Fixing MF7/MT2 key name: LHTR → LTHR

### DIFF
--- a/src/endf/mf7.py
+++ b/src/endf/mf7.py
@@ -43,16 +43,16 @@ def parse_mf7_mt2(file_obj: TextIO) -> dict:
         params, W = get_tab1_record(file_obj)
         return {'SB': params[0], 'W': W}
 
-    ZA, AWR, LHTR, *_ = get_head_record(file_obj)
-    data = {'ZA': ZA, 'AWR': AWR, 'LHTR': LHTR}
+    ZA, AWR, LTHR, *_ = get_head_record(file_obj)
+    data = {'ZA': ZA, 'AWR': AWR, 'LTHR': LTHR}
 
-    if LHTR == 1:
+    if LTHR == 1:
         # coherent elastic
         data['coherent'] = get_coherent_elastic(file_obj)
-    elif LHTR == 2:
+    elif LTHR == 2:
         # incoherent elastic
         data['incoherent'] = get_incoherent_elastic(file_obj)
-    elif LHTR == 3:
+    elif LTHR == 3:
         # mixed coherent / incoherent elastic
         data['coherent'] = get_coherent_elastic(file_obj)
         data['incoherent'] = get_incoherent_elastic(file_obj)


### PR DESCRIPTION
The parsed dictionary key for the thermal elastic scattering law flag in MF7/MT2 is currently stored as LHTR in the endf-python package.  The correct ENDF-6 variable name is LTHR (Law for THermal elastic Reaction), as defined in the ENDF-6 Formats Manual (ENDF-102, Section 7.2) and used consistently in NJOY2016, PREPRO, and other processing codes.

This typo causes downstream code that looks up ['LTHR'] to silently get a default of 0 (of course depending on how the code is setup), making it appear that no elastic data is present even when the file correctly contains LTHR data.