### PR TITLE
Run tests on Python 3.14

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Run tests on Python 3.14 ([#38](https://github.com/paulromano/endf-python/pull/38))
+
+### Fixed
+
+* Fixing MF7/MT2 key name: LHTR → LTHR ([#37](https://github.com/paulromano/endf-python/pull/37))
+
 ## [0.1.12]
 
 ### Added


### PR DESCRIPTION
This PR adds Python 3.14 (and 3.14 free-threaded) to the test matrix.