### PR TITLE
Fix bug when storing fission energy release components

### DIFF
--- a/src/endf/mf1.py
+++ b/src/endf/mf1.py
@@ -191,7 +191,7 @@ def parse_mf1_mt458(file_obj: TextIO) -> dict:
             (_, _, LDRV, IFC), EIFC = get_tab1_record(file_obj)
 
             # Determine which component it is and replace in dictionary
-            name = components[IFC]
+            name = components[IFC-1]
             data[name] = {'LDRV': LDRV, 'EIFC': EIFC}
 
     return data


### PR DESCRIPTION
This corrects an off-by-one index error when storing the fission energy release components. Previously, component were not being stored under the correct key.